### PR TITLE
Define MPG Minerva as resource

### DIFF
--- a/_extensions/mpim/_extension.yml
+++ b/_extensions/mpim/_extension.yml
@@ -17,7 +17,7 @@ contributes:
       navigation-mode: linear
       auto-stretch: true
       center: true
-      format-resources:
+      resources:
         - MPG_Minerva_mpg-green.png
       filters:
         - file-dependencies.lua


### PR DESCRIPTION
This should prevent the file from being copied to the top-level directory during build.

Using `format-resources` is meant to files that need to be copied to the input directory, i.e. when building LaTeX documents (see [docs](https://quarto.org/docs/extensions/formats.html#format-resources)).