### PR TITLE
Add CSS classes for corporate design colors

### DIFF
--- a/_extensions/mpim/colors.scss
+++ b/_extensions/mpim/colors.scss
@@ -1,0 +1,39 @@
+//
+// Color system
+//
+$white:    #fff;
+$black:    #000;
+$green:   #006c66;
+$darkgreen: #005555;
+$darkgrey: #777777;
+$grey: #a7a7a8;
+$lightgrey: #eeeeee;
+$lightgreen: #c6d325;
+$darkblue: #29485d;
+$lightblue: #00b1ea;
+$orange: #ef7c00;
+
+$primary:       $green;
+$secondary:     $grey;
+$success:       $green;
+$info:          $lightgreen;
+$warning:       $orange;
+$danger:        $orange;
+$light:         $lightgrey;
+$dark:          $darkgrey;
+
+.darkgreen {
+    color: $darkgreen;
+}
+
+.green {
+    color: $green;
+}
+
+.lightgreen {
+    color: $lightgreen;
+}
+
+.orange {
+    color: $orange;
+}

--- a/_extensions/mpim/poster.scss
+++ b/_extensions/mpim/poster.scss
@@ -1,32 +1,8 @@
-/*-- scss:defaults --*/
+@import "colors";
 
 $theme: "poster";
 
-//
-// Color system
-//
-
-$white:    #fff;
-$black:    #000;
-$green:   #006c66;
-$darkgreen: #005555;
-$darkgrey: #777777;
-$grey: #a7a7a8;
-$lightgrey: #eeeeee;
-$lightgreen: #c6d325;
-$darkblue: #29485d;
-$lightblue: #00b1ea;
-$orange: #ef7c00;
-
-$primary:       $green;
-$secondary:     $grey;
-$success:       $green;
-$info:          $lightgreen;
-$warning:       $orange;
-$danger:        $orange;
-$light:         $lightgrey;
-$dark:          $darkgrey;
-
+// Define ISO page sizes
 $min-contrast-ratio:   2.75;
 
 $A0_long: 1189mm;

--- a/_extensions/mpim/slides.scss
+++ b/_extensions/mpim/slides.scss
@@ -80,6 +80,22 @@ h2 {
     text-align: right;
 }
 
+.darkgreen {
+    color: $darkgreen;
+}
+
+.green {
+    color: $green;
+}
+
+.lightgreen {
+    color: $lightgreen;
+}
+
+.orange {
+    color: $orange;
+}
+
 .attribution {
   transform: translateX(calc(50% + 2em)) rotate(-90deg);
   position: absolute;

--- a/_extensions/mpim/slides.scss
+++ b/_extensions/mpim/slides.scss
@@ -1,25 +1,4 @@
-/*-- scss:defaults --*/
-
-$white:    #fff;
-$black:    #000;
-$green:   #006c66;
-$darkgreen: #005555;
-$darkgrey: #777777;
-$grey: #a7a7a8;
-$lightgrey: #eeeeee;
-$lightgreen: #c6d325;
-$darkblue: #29485d;
-$lightblue: #00b1ea;
-$orange: #ef7c00;
-
-$primary:       $green;
-$secondary:     $grey;
-$success:       $green;
-$info:          $lightgreen;
-$warning:       $orange;
-$danger:        $orange;
-$light:         $lightgrey;
-$dark:          $darkgrey;
+@import "colors";
 
 $presentation-heading-font: "Roboto";
 $presentation-heading-color: $green;
@@ -78,22 +57,6 @@ h2 {
 
 .right {
     text-align: right;
-}
-
-.darkgreen {
-    color: $darkgreen;
-}
-
-.green {
-    color: $green;
-}
-
-.lightgreen {
-    color: $lightgreen;
-}
-
-.orange {
-    color: $orange;
 }
 
 .attribution {

--- a/slides.qmd
+++ b/slides.qmd
@@ -25,6 +25,15 @@ date: 2024-05-31
 
 ::::
 
+## Colors
+
+* You can use pre-defined colors that adhere to the MPI-M design guidelines
+* To apply a color, add the relevant CSS class:
+  ```markdown
+  This is a sentence with [colored words]{.green} in between.
+  ```
+* The available colors are [**darkgreen**]{.darkgreen}, [**green**]{.green}, [**lightgreen**]{.lightgreen}, and [**orange**]{.orange}
+
 ## More Information
 
 You can learn more about controlling the appearance of RevealJS output here: <https://quarto.org/docs/presentations/revealjs/>


### PR DESCRIPTION
This PR:
* adds CSS classes to more easily apply the pre-defined corporate design colors
* moves color definitions into a separate stylesheet that is imported for slides/poster
* adds an example on the usage of pre-defined colors