### PR TITLE
Add chapter marks and update example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /poster.html
 /slides_files
 /poster_files
+*.quarto_ipynb

--- a/_extensions/mpim/slide_background.css
+++ b/_extensions/mpim/slide_background.css
@@ -5,7 +5,7 @@
     background-position: center;
 }
 
-.reveal .level1 .slide-background-content {
+.separator .slide-background-content {
     background-image: url("slide_separators/dots.png");
     background-size: contain;
     background-repeat: no-repeat;

--- a/_extensions/mpim/slide_background.css
+++ b/_extensions/mpim/slide_background.css
@@ -12,6 +12,90 @@
     background-position: center;
 }
 
+.separator-01 .slide-background-content {
+    background-image: url("slide_separators/sep01.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.separator-02 .slide-background-content {
+    background-image: url("slide_separators/sep02.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.separator-03 .slide-background-content {
+    background-image: url("slide_separators/sep03.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.separator-04 .slide-background-content {
+    background-image: url("slide_separators/sep04.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.separator-05 .slide-background-content {
+    background-image: url("slide_separators/sep05.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.separator-06 .slide-background-content {
+    background-image: url("slide_separators/sep06.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.separator-07 .slide-background-content {
+    background-image: url("slide_separators/sep07.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.separator-08 .slide-background-content {
+    background-image: url("slide_separators/sep08.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.separator-09 .slide-background-content {
+    background-image: url("slide_separators/sep09.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.separator-10 .slide-background-content {
+    background-image: url("slide_separators/sep10.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.separator-11 .slide-background-content {
+    background-image: url("slide_separators/sep11.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.separator-12 .slide-background-content {
+    background-image: url("slide_separators/sep12.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
 .no-background .slide-background-content {
     display: none;
 }

--- a/slides.qmd
+++ b/slides.qmd
@@ -1,18 +1,24 @@
 ---
-title: Building useful datasets for <br/> Earth System Model output
+title: Using the MPI-M quarto theme
 format:
   mpim-revealjs: default
 author:
   - name: Tobias Kölling
   - name: Lukas Kluft
-date: 2024-05-31
+date: 2025-12-15
 ---
 
 ## Introduction
 
-*TODO* Create an example file that demonstrates the formatting and features of your format.
+The MPI-M Quarto theme is demonstrated in this example, which also provides examples of additional functionality that extends the usual Quarto options.
 
-## Images
+## Polaroid effect for images
+
+You can add a polaroid effect to embedded images:
+
+```{markdown}
+![Alt text](image.png){.polaroid}
+```
 
 ::::{.columns}
 :::{.column}
@@ -22,17 +28,36 @@ date: 2024-05-31
 :::{.column}
 ![MPG logo with polaroid effect](MPG_Minerva_mpg-green.png){height=300px .polaroid}
 :::
-
 ::::
 
 ## Colors
 
 * You can use pre-defined colors that adhere to the MPI-M design guidelines
 * To apply a color, add the relevant CSS class:
-  ```markdown
+  ```{markdown}
   This is a sentence with [colored words]{.green} in between.
   ```
 * The available colors are [**darkgreen**]{.darkgreen}, [**green**]{.green}, [**lightgreen**]{.lightgreen}, and [**orange**]{.orange}
+
+## Transition slides
+
+You can insert a transition slide by adding the `{.separator}` class to the heading:
+
+```{markdown}
+# New chapter {.separator}
+```
+
+In addition, there are twelve numbered section separators available:
+
+```{markdown}
+# Chapter 01 {.separator-01}
+```
+
+_see next slides_
+
+# New chapter {.separator}
+
+# Chapter 01 {.separator-01}
 
 ## More Information
 


### PR DESCRIPTION
This PR:
* disables the automatic styling of H1 headings (this often conflicts with slide content)
* enables the explicit use of `.separator` and `.separator-NN` to still make use of the corporate design
* updates the example presentation 